### PR TITLE
Add Mutable View for Struct Elements

### DIFF
--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -573,6 +573,24 @@ public abstract interface class com/amazon/ionelement/api/LobElement : com/amazo
 	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/LobElement;
 }
 
+public abstract interface class com/amazon/ionelement/api/MutableStructFields : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public abstract fun add (Lcom/amazon/ionelement/api/StructField;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun add (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElement;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun containsField (Ljava/lang/String;)Z
+	public abstract fun get (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun getAll (Ljava/lang/String;)Ljava/lang/Iterable;
+	public abstract fun getFields ()Ljava/util/Map;
+	public abstract fun getOptional (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun plusAssign (Lcom/amazon/ionelement/api/StructField;)V
+	public abstract fun plusAssign (Ljava/lang/Iterable;)V
+	public abstract fun remove (Ljava/lang/String;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun removeAll (Ljava/lang/String;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun set (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElement;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun setAll (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/MutableStructFields;
+	public abstract fun toStruct ()Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun toStruct (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+}
+
 public abstract interface class com/amazon/ionelement/api/SeqElement : com/amazon/ionelement/api/ContainerElement {
 	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SeqElement;
 	public abstract fun getValues ()Ljava/util/List;
@@ -606,10 +624,12 @@ public abstract interface class com/amazon/ionelement/api/StringElement : com/am
 
 public abstract interface class com/amazon/ionelement/api/StructElement : com/amazon/ionelement/api/ContainerElement {
 	public abstract fun containsField (Ljava/lang/String;)Z
+	public abstract fun copy (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun get (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
 	public abstract fun getAll (Ljava/lang/String;)Ljava/lang/Iterable;
 	public abstract fun getFields ()Ljava/util/Collection;
+	public abstract fun getMutableFields ()Lcom/amazon/ionelement/api/MutableStructFields;
 	public abstract fun getOptional (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
 	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/StructElement;
@@ -656,5 +676,9 @@ public abstract interface class com/amazon/ionelement/api/TimestampElement : com
 	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
 	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/TimestampElement;
 	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/TimestampElement;
+}
+
+public final class com/amazon/ionelement/impl/MutableStructFieldsImplKt {
+	public static final fun buildStruct (Lkotlin/jvm/functions/Function1;)Lcom/amazon/ionelement/api/StructElement;
 }
 

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -425,6 +425,9 @@ public interface StructElement : ContainerElement {
     /** This struct's unordered collection of fields. */
     public val fields: Collection<StructField>
 
+    /** A mutable shallow copy of this struct's fields */
+    public val mutableFields: MutableStructFields
+
     /**
      * Retrieves the value of the first field found with the specified name.
      *
@@ -442,6 +445,13 @@ public interface StructElement : ContainerElement {
 
     /** Returns true if this StructElement has at least one field with the given field name. */
     public fun containsField(fieldName: String): Boolean
+
+    /**
+     * Creates a shallow copy of this struct with its fields replaced by the given [fields] that have the same name.
+     *
+     * If multiple fields with the same name exist they are all replaced by the new fields.
+     */
+    public fun copy(fields: Iterable<StructField>): StructElement
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement
     override fun withAnnotations(vararg additionalAnnotations: String): StructElement

--- a/src/com/amazon/ionelement/api/MutableStructFields.kt
+++ b/src/com/amazon/ionelement/api/MutableStructFields.kt
@@ -1,0 +1,67 @@
+package com.amazon.ionelement.api
+
+/**
+ * Represents a mutable view of a collection of struct fields.
+ */
+public interface MutableStructFields : Iterable<StructField> {
+
+    public val fields: MutableMap<String, MutableList<AnyElement>>
+
+    /**
+     * Retrieves the value of the first field found with the specified name.
+     *
+     * In the case of multiple fields with the specified name, the caller assumes that one is picked at random.
+     *
+     * @throws IonElementException If there are no fields with the specified [fieldName].
+     */
+    public operator fun get(fieldName: String): AnyElement
+
+    /** The same as [get] but returns a null reference if the field does not exist.  */
+    public fun getOptional(fieldName: String): AnyElement?
+
+    /** Retrieves all values with a given field name. Returns an empty iterable if the field does not exist. */
+    public fun getAll(fieldName: String): Iterable<AnyElement>
+
+    /** Returns true if this StructElement has at least one field with the given field name. */
+    public fun containsField(fieldName: String): Boolean
+
+    /**
+     * If one or more fields with the specified name already exists, this replaces the value of the *first* field found.
+     *
+     * Otherwise, a new field with the given name and value is added to the collection
+     */
+    public operator fun set(fieldName: String, value: IonElement): MutableStructFields
+
+    /**
+     * Adds all the given fields to the collection. For existing fields with the same names as the fields provided, all
+     * instances of those fields will be removed.
+     */
+    public fun setAll(fields: Iterable<StructField>): MutableStructFields
+
+    /**
+     * Adds a new field to the collection with the given name and value. The collection may have multiple fields with
+     * the same name.
+     */
+    public fun add(fieldName: String, value: IonElement): MutableStructFields
+
+    /** Adds the given field to the collection. The collection may have multiple fields with the same name. */
+    public fun add(field: StructField): MutableStructFields
+
+    /** Removes a random occurrence of a field found with the given name or does nothing if no field exists */
+    public fun remove(fieldName: String): MutableStructFields
+
+    /** Removes all fields found with the given name or does nothing if no fields exist */
+    public fun removeAll(fieldName: String): MutableStructFields
+
+    /** Adds the given field to the collection */
+    public operator fun plusAssign(field: StructField)
+
+    /** Adds all the given fields to the collection */
+    public operator fun plusAssign(fields: Iterable<StructField>)
+
+    /** Creates a new instance of a StructElement from the current fields with the given annotations and metas */
+    public fun toStruct(annotations: List<String>, metas: MetaContainer): StructElement
+
+    /** Creates a new instance of a StructElement from the current fields */
+    public fun toStruct(): StructElement
+}

--- a/src/com/amazon/ionelement/impl/MutableStructFieldsImpl.kt
+++ b/src/com/amazon/ionelement/impl/MutableStructFieldsImpl.kt
@@ -1,0 +1,109 @@
+package com.amazon.ionelement.impl
+
+import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.MutableStructFields
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.StructField
+import com.amazon.ionelement.api.emptyIonStruct
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionStructOf
+
+internal class MutableStructFieldsImpl(override val fields: MutableMap<String, MutableList<AnyElement>>) :
+    MutableStructFields {
+
+    override fun get(fieldName: String): AnyElement {
+        return requireNotNull(fields[fieldName]?.firstOrNull()) {
+            "Required struct field '$fieldName' missing"
+        }
+    }
+
+    override fun getOptional(fieldName: String): AnyElement? {
+        return fields[fieldName]?.firstOrNull()
+    }
+
+    override fun getAll(fieldName: String): Iterable<AnyElement> {
+        return fields[fieldName] ?: mutableListOf()
+    }
+
+    override fun containsField(fieldName: String): Boolean {
+        return fieldName in fields
+    }
+
+    override fun set(fieldName: String, value: IonElement): MutableStructFields {
+        value as AnyElement
+        if (fieldName in fields) {
+            fields[fieldName]?.clear()
+            fields[fieldName]?.add(value)
+        } else {
+            fields[fieldName] = mutableListOf(value)
+        }
+
+        return this
+    }
+
+    override fun setAll(fields: Iterable<StructField>): MutableStructFields {
+        fields.groupByTo(mutableMapOf(), { it.name }, { it.value }).forEach { (name, values) ->
+            this.fields[name] = values
+        }
+        return this
+    }
+
+    override fun add(fieldName: String, value: IonElement): MutableStructFields {
+        value as AnyElement
+        val values = fields[fieldName]
+        if (values == null) {
+            fields[fieldName] = mutableListOf(value)
+        } else {
+            values.add(value)
+        }
+
+        return this
+    }
+
+    override fun add(field: StructField): MutableStructFields {
+        add(field.name, field.value)
+        return this
+    }
+
+    override fun remove(fieldName: String): MutableStructFields {
+        fields[fieldName]?.removeAt(0)
+        return this
+    }
+
+    override fun removeAll(fieldName: String): MutableStructFields {
+        fields[fieldName]?.clear()
+        return this
+    }
+
+    override fun plusAssign(field: StructField) {
+        add(field.name, field.value)
+    }
+
+    override fun plusAssign(fields: Iterable<StructField>) {
+        fields.forEach { add(it) }
+    }
+
+    override fun toStruct(annotations: List<String>, metas: MetaContainer): StructElement {
+        return ionStructOf(this, annotations, metas)
+    }
+
+    override fun toStruct(): StructElement {
+        return ionStructOf(this)
+    }
+
+    override fun iterator(): Iterator<StructField> {
+        return fields.flatMap { (fieldName, values) ->
+            values.map { value ->
+                field(fieldName, value)
+            }
+        }.iterator()
+    }
+}
+
+public fun buildStruct(body: MutableStructFields.() -> Unit): StructElement {
+    val fields = emptyIonStruct().mutableFields
+    body(fields)
+    return fields.toStruct(emptyList(), emptyMap())
+}

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -60,10 +60,17 @@ internal class StructElementImpl(
                 fieldsByNameBackingField =
                     fields
                         .groupBy { it.name }
-                        .map { structFieldGroup -> structFieldGroup.key to structFieldGroup.value.map { it.value }.toPersistentList() }
+                        .map { structFieldGroup ->
+                            structFieldGroup.key to structFieldGroup.value.map { it.value }.toPersistentList()
+                        }
                         .toMap().toPersistentMap()
             }
             return fieldsByNameBackingField!!
+        }
+
+    override val mutableFields: MutableStructFields
+        get() {
+            return MutableStructFieldsImpl(fieldsByName.mapValues { it.value.toMutableList() }.toMutableMap())
         }
 
     override fun get(fieldName: String): AnyElement =
@@ -76,11 +83,19 @@ internal class StructElementImpl(
 
     override fun containsField(fieldName: String): Boolean = fieldsByName.containsKey(fieldName)
 
+    override fun copy(fields: Iterable<StructField>): StructElement {
+        return mutableFields.setAll(fields).toStruct(annotations, metas)
+    }
+
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElementImpl =
         StructElementImpl(allFields, annotations.toPersistentList(), metas.toPersistentMap())
 
-    override fun withAnnotations(vararg additionalAnnotations: String): StructElementImpl = _withAnnotations(*additionalAnnotations)
-    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withAnnotations(vararg additionalAnnotations: String): StructElementImpl =
+        _withAnnotations(*additionalAnnotations)
+
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElementImpl =
+        _withAnnotations(additionalAnnotations)
+
     override fun withoutAnnotations(): StructElementImpl = _withoutAnnotations()
     override fun withMetas(additionalMetas: MetaContainer): StructElementImpl = _withMetas(additionalMetas)
     override fun withMeta(key: String, value: Any): StructElementImpl = _withMeta(key, value)

--- a/test/com/amazon/ionelement/MutableStructFieldsTests.kt
+++ b/test/com/amazon/ionelement/MutableStructFieldsTests.kt
@@ -1,0 +1,207 @@
+package com.amazon.ionelement
+
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionListOf
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.loadSingleElement
+import com.amazon.ionelement.impl.buildStruct
+import java.lang.IllegalArgumentException
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MutableStructFieldsTests {
+    @Test
+    fun `StructElement to mutable fields back to StructElement`() {
+        assertEquals(testStruct, testStruct.mutableFields.toStruct())
+    }
+
+    @Test
+    fun `StructElement to mutable fields back to StructElement with annotations and metas`() {
+        assertEquals(
+            testStruct
+                .withAnnotations("foo", "bar")
+                .withMeta("meta", 1),
+
+            testStruct.mutableFields.toStruct(listOf("foo", "bar"), mapOf("meta" to 1))
+        )
+    }
+
+    @Test
+    fun get() {
+        val mutableFields = testStruct.mutableFields
+        assertEquals(ionString("123-456-789"), mutableFields["isbn"].asString())
+        assertThrows<IllegalArgumentException> {
+            mutableFields["nothing"]
+        }
+    }
+
+    @Test
+    fun getOptional() {
+        val mutableFields = testStruct.mutableFields
+        assertNull(mutableFields.getOptional("nothing"))
+        assertEquals(ionString("123-456-789"), mutableFields.getOptional("isbn")?.asString())
+    }
+
+    @Test
+    fun getAll() {
+        val mutableFields = testStruct.mutableFields
+        assertEquals(2, mutableFields.getAll("author").count())
+        assertEquals(
+            setOf(
+                ionStructOf("lastname" to ionString("Doe"), "firstname" to ionString("Jane")),
+                ionStructOf("lastname" to ionString("Smith"), "firstname" to ionString("Jane"))
+            ),
+            mutableFields.getAll("author").map { it.asStruct() }.toSet()
+        )
+        assertEquals(0, mutableFields.getAll("nothing").count())
+    }
+
+    @Test
+    fun containsField() {
+        val mutableFields = testStruct.mutableFields
+        assertTrue(mutableFields.containsField("author"))
+        assertTrue(mutableFields.containsField("isbn"))
+        assertFalse(mutableFields.containsField("nothing"))
+    }
+
+    @Test
+    fun set() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields["nothing"] = ionInt(0)
+        mutableFields["isbn"] = ionInt(1)
+        mutableFields["author"] = ionInt(2)
+
+        assertEquals(ionInt(0), mutableFields["nothing"].asInt())
+        assertEquals(ionInt(1), mutableFields["isbn"].asInt())
+        assertEquals(1, mutableFields.getAll("author").count())
+        assertEquals(ionInt(2), mutableFields.getAll("author").first().asInt())
+    }
+
+    @Test
+    fun setAll() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields.setAll(
+            listOf(
+                field("year", ionInt(2000)),
+                field("year", ionInt(2012))
+            )
+        )
+        mutableFields.setAll(
+            listOf(
+                field("author", ionString("Alice")),
+                field("author", ionString("Bob"))
+            )
+        )
+        assertEquals(
+            setOf(ionInt(2000).asAnyElement(), ionInt(2012).asAnyElement()),
+            mutableFields.getAll("year").toSet()
+        )
+
+        assertEquals(
+            setOf(ionString("Alice").asAnyElement(), ionString("Bob").asAnyElement()),
+            mutableFields.getAll("author").toSet()
+        )
+    }
+
+    @Test
+    fun add() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields.add(field("year", ionInt(2000)))
+        mutableFields.add("year", ionInt(2012))
+        mutableFields.add("author", ionString("Alice"))
+
+        assertEquals(
+            setOf(ionInt(2000).asAnyElement(), ionInt(2012).asAnyElement()),
+            mutableFields.getAll("year").toSet()
+        )
+
+        assertEquals(
+            setOf(ionString("Alice").asAnyElement()).plus(testStruct.getAll("author")),
+            mutableFields.getAll("author").toSet()
+        )
+    }
+
+    @Test
+    fun plusAssign() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields += field("year", ionInt(2000))
+        mutableFields += listOf(field("year", ionInt(2012)), field("year", ionInt(2021)))
+
+        assertEquals(
+            setOf(ionInt(2000).asAnyElement(), ionInt(2012).asAnyElement(), ionInt(2021).asAnyElement()),
+            mutableFields.getAll("year").toSet()
+        )
+    }
+
+    @Test
+    fun remove() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields.remove("author")
+        mutableFields.remove("author")
+
+        assertNull(mutableFields.getOptional("author"))
+    }
+
+    @Test
+    fun removeAll() {
+        val mutableFields = testStruct.mutableFields
+        mutableFields.removeAll("author")
+
+        assertNull(mutableFields.getOptional("author"))
+    }
+
+    @Test
+    fun buildStructTest() {
+        val actual = buildStruct {
+            add("isbn", ionString("123-456-789"))
+            add(
+                "author",
+                buildStruct {
+                    add("lastname", ionString("Doe"))
+                    add("firstname", ionString("Jane"))
+                }
+            )
+            add(
+                "author",
+                buildStruct {
+                    add("lastname", ionString("Smith"))
+                    add("firstname", ionString("Jane"))
+                }
+            )
+            add("title", ionString("AWS User Guide"))
+            add("category", ionListOf(ionSymbol("Non-Fiction"), ionSymbol("Technology")))
+        }
+
+        assertEquals(testStruct, actual)
+    }
+
+    companion object {
+        val testStruct = loadSingleElement(
+            """
+            {
+              isbn: "123-456-789",
+              author: {
+                lastname: "Doe",
+                firstname: "Jane"
+              },
+              author: {
+                lastname: "Smith",
+                firstname: "Jane"
+              },
+              title: "AWS User Guide",
+              category: [
+                'Non-Fiction',
+                'Technology'
+              ]
+            }
+        """
+        ).asStruct()
+    }
+}

--- a/test/com/amazon/ionelement/demos/java/MutableStructFields.java
+++ b/test/com/amazon/ionelement/demos/java/MutableStructFields.java
@@ -1,0 +1,27 @@
+package com.amazon.ionelement.demos.java;
+
+import com.amazon.ionelement.api.Ion;
+import com.amazon.ionelement.api.StructElement;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static com.amazon.ionelement.api.ElementLoader.loadSingleElement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MutableStructFields {
+
+    @Test
+    void CreateUpdatedStructFromExistingStruct() {
+        StructElement original = loadSingleElement("{name:\"Alice\",scores:{darts:100,billiards:15,}}").asStruct();
+
+        StructElement expected = loadSingleElement("{name:\"Alice\",scores:{darts:100,billiards:30,pingPong:200,}}").asStruct();
+
+        StructElement updated = original.copy(Arrays.asList(Ion.field("scores", original.get("scores").asStruct().getMutableFields()
+                .add("pingPong", Ion.ionInt(200))
+                .set("billiards", Ion.ionInt(30))
+                .toStruct())));
+
+        assertEquals(expected, updated);
+    }
+}

--- a/test/com/amazon/ionelement/demos/kotlin/MutableStructFields.kt
+++ b/test/com/amazon/ionelement/demos/kotlin/MutableStructFields.kt
@@ -1,0 +1,46 @@
+package com.amazon.ionelement.demos.kotlin
+
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.loadSingleElement
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class MutableStructFields {
+    @Test
+    fun `create updated struct from existing struct`() {
+        val original = loadSingleElement(
+            """
+            {
+                name: "Alice",               
+                scores: {
+                    darts: 100,
+                    billiards: 15,
+                }
+            }
+            """.trimIndent()
+        ).asStruct()
+
+        val expected = loadSingleElement(
+            """
+                        {
+                            name: "Alice",               
+                            scores: {
+                                darts: 100,
+                                billiards: 30,
+                                pingPong: 200,
+                            }
+                        }
+            """.trimIndent()
+        ).asStruct()
+
+        val updated = original.mutableFields.set(
+            "scores",
+            original["scores"].asStruct().mutableFields
+                .set("pingPong", ionInt(200))
+                .set("billiards", ionInt(30))
+                .toStruct()
+        ).toStruct()
+
+        assertEquals(expected, updated)
+    }
+}


### PR DESCRIPTION

Issue #, if available:

Description of changes: 

Adds a MutableStructFields interface which represents an iterable sequence of mutable fields that can be used to construct a StructElement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

