### PR TITLE
Updates StructElement.update() to be more Java-friendly

### DIFF
--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -631,7 +631,8 @@ public abstract interface class com/amazon/ionelement/api/StructElement : com/am
 	public abstract fun getFields ()Ljava/util/Collection;
 	public abstract fun getOptional (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
 	public abstract fun mutableFields ()Lcom/amazon/ionelement/api/MutableStructFields;
-	public abstract fun update (Lkotlin/jvm/functions/Function1;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun update (Ljava/util/function/Consumer;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract synthetic fun update (Lkotlin/jvm/functions/Function1;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/StructElement;
 	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/StructElement;

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -20,6 +20,7 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.constraintError
+import java.util.function.Consumer
 import kotlinx.collections.immutable.PersistentCollection
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
@@ -75,9 +76,15 @@ internal class StructElementImpl(
         )
     }
 
-    override fun update(body: MutableStructFields.() -> Unit): StructElement {
+    override fun update(mutator: MutableStructFields.() -> Unit): StructElement {
         val mutableFields = mutableFields()
-        body(mutableFields)
+        mutableFields.apply(mutator)
+        return ionStructOf(mutableFields, annotations, metas)
+    }
+
+    override fun update(mutator: Consumer<MutableStructFields>): StructElement {
+        val mutableFields = mutableFields()
+        mutator.accept(mutableFields)
         return ionStructOf(mutableFields, annotations, metas)
     }
 

--- a/test/com/amazon/ionelement/demos/java/MutableStructFieldsDemo.java
+++ b/test/com/amazon/ionelement/demos/java/MutableStructFieldsDemo.java
@@ -18,15 +18,13 @@ public class MutableStructFieldsDemo {
         StructElement expected = loadSingleElement(
                 "{name:\"Alice\",scores:{darts:100,billiards:30,pingPong:200,}}").asStruct();
 
-        StructElement updated = original.update(fields -> {
+        StructElement updated = original.update(fields ->
             fields.set("scores",
-                    original.get("scores").asStruct().update(scoreFields -> {
+                    fields.get("scores").asStruct().update(scoreFields -> {
                         scoreFields.add("pingPong", Ion.ionInt(200));
                         scoreFields.set("billiards", Ion.ionInt(30));
-                        return Unit.INSTANCE;
-                    }));
-            return Unit.INSTANCE;
-        });
+                    })
+        ));
 
         assertEquals(expected, updated);
     }


### PR DESCRIPTION

**Issue #, if available:**

None

**Description of changes:**

Updates the `update()` function so that Java callers do not have to return `Unit.INSTANCE` from their lambda expressions.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

