### PR TITLE
Fix equals implementation to respect that anyone is allowed to implement IonElement

### DIFF
--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -183,6 +183,13 @@ public final class com/amazon/ionelement/api/ElementTypeKt {
 	public static final fun toElementType (Lcom/amazon/ion/IonType;)Lcom/amazon/ionelement/api/ElementType;
 }
 
+public final class com/amazon/ionelement/api/Equivalence {
+	public static final fun areElementsEqual (Lcom/amazon/ionelement/api/IonElement;Lcom/amazon/ionelement/api/IonElement;)Z
+	public static final fun areFieldsEqual (Lcom/amazon/ionelement/api/StructField;Lcom/amazon/ionelement/api/StructField;)Z
+	public static final fun hashElement (Lcom/amazon/ionelement/api/IonElement;)I
+	public static final fun hashField (Lcom/amazon/ionelement/api/StructField;)I
+}
+
 public abstract interface class com/amazon/ionelement/api/FloatElement : com/amazon/ionelement/api/IonElement {
 	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/FloatElement;
 	public abstract fun getDoubleValue ()D
@@ -334,9 +341,11 @@ public final class com/amazon/ionelement/api/IonBinaryLocation : com/amazon/ione
 public abstract interface class com/amazon/ionelement/api/IonElement {
 	public abstract fun asAnyElement ()Lcom/amazon/ionelement/api/AnyElement;
 	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun equals (Ljava/lang/Object;)Z
 	public abstract fun getAnnotations ()Ljava/util/List;
 	public abstract fun getMetas ()Ljava/util/Map;
 	public abstract fun getType ()Lcom/amazon/ionelement/api/ElementType;
+	public abstract fun hashCode ()I
 	public abstract fun isNull ()Z
 	public abstract fun toString ()Ljava/lang/String;
 	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/IonElement;

--- a/src/com/amazon/ionelement/api/ByteArrayView.kt
+++ b/src/com/amazon/ionelement/api/ByteArrayView.kt
@@ -15,7 +15,13 @@
 
 package com.amazon.ionelement.api
 
-/** An immutable wrapper over a [byte[]]. */
+/**
+ * An immutable wrapper over a [ByteArray].
+ *
+ * This type uses value-based equality—two [ByteArrayView]s are equal if they have equal content.
+ * Implementations MUST override [Any.hashCode] to return the same integer that would be return by calling
+ * [copyOfBytes]`()`.[contentHashCode][ByteArray.contentHashCode]`()`.
+ */
 public interface ByteArrayView : Iterable<Byte> {
     public fun size(): Int
     public operator fun get(index: Int): Byte

--- a/src/com/amazon/ionelement/api/Equivalence.kt
+++ b/src/com/amazon/ionelement/api/Equivalence.kt
@@ -86,7 +86,9 @@ private fun AnyElement.isEquivalentTo(other: AnyElement): Boolean {
 /**
  * Calculates the hash code of an [IonElement].
  *
- * Implementations of [IonElement] MAY NOT calculate their own hash codes, but MAY cache the result of this function.
+ * Implementations of [IonElement] MAY NOT calculate their own hash codes. However, they MAY store the result of this
+ * function as a private field. The result of this function may change from one release to another—do not put this
+ * value in any persistent storage.
  */
 public fun hashElement(ionElement: IonElement): Int {
     val element = ionElement.asAnyElement()
@@ -121,6 +123,10 @@ public fun hashElement(ionElement: IonElement): Int {
 
 /**
  * Calculates the hash code of a [StructField].
+ *
+ * Implementations of [StructField] MAY NOT calculate their own hash codes. However, they MAY store the result of this
+ * function as a private field. The result of this function may change from one release to another—do not put this
+ * value in any persistent storage.
  */
 public fun hashField(structField: StructField): Int {
     return structField.name.hashCode() * 31 + structField.value.hashCode()

--- a/src/com/amazon/ionelement/api/Equivalence.kt
+++ b/src/com/amazon/ionelement/api/Equivalence.kt
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+@file:JvmName("Equivalence")
+package com.amazon.ionelement.api
+
+import com.amazon.ion.Decimal
+import com.amazon.ionelement.api.ElementType.*
+
+/**
+ * Checks if two [IonElement]s are equal.
+ *
+ * This function is normative for equality of [IonElement]s.
+ * All [IonElement] implementations must override [Any.equals] in a way that is equivalent to calling this function.
+ */
+public fun areElementsEqual(left: IonElement, right: IonElement): Boolean {
+    return left.asAnyElement().isEquivalentTo(right.asAnyElement())
+}
+
+/**
+ * Checks if two [StructField]s are equal.
+ *
+ * This function is normative for equality of [StructField]s.
+ * All [StructField] implementations must override [Any.equals] in a way that is equivalent to calling this function.
+ */
+public fun areFieldsEqual(left: StructField, right: StructField): Boolean = left.name == right.name && left.value == right.value
+
+/**
+ * Checks if this [AnyElement] is equal to some other object.
+ */
+internal fun AnyElement.isEquivalentTo(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is AnyElement) return false
+    return this.isEquivalentTo(other)
+}
+
+/**
+ * Internal only function that is equivalent to [areElementsEqual]
+ */
+private fun AnyElement.isEquivalentTo(other: AnyElement): Boolean {
+    if (this === other) return true
+    val thisType = this.type
+    if (thisType != other.type) return false
+    if (annotations != other.annotations) return false
+    // Metas intentionally not included here.
+
+    return if (isNull) {
+        // Already verified that they are the same type
+        other.isNull
+    } else if (other.isNull) {
+        false
+    } else
+    // Matching an enum rather than a type allows the Kotlin compiler
+    // to use a table switch instead of a chain of if/else comparisons.
+        when (thisType) {
+            BOOL -> booleanValue == other.booleanValue
+            INT -> when {
+                integerSize != other.integerSize -> false
+                integerSize == IntElementSize.LONG -> longValue == other.longValue
+                else -> bigIntegerValue == other.bigIntegerValue
+            }
+            // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
+            FLOAT -> doubleValue.compareTo(other.doubleValue) == 0
+            // `==` considers `0d0` and `-0d0` to be equivalent.  `Decimal.equals` does not.
+            DECIMAL -> Decimal.equals(decimalValue, other.decimalValue)
+            TIMESTAMP -> timestampValue == other.timestampValue
+            STRING -> stringValue == other.stringValue
+            SYMBOL -> symbolValue == other.symbolValue
+            BLOB -> blobValue == other.blobValue
+            CLOB -> clobValue == other.clobValue
+            LIST -> listValues == other.listValues
+            SEXP -> sexpValues == other.sexpValues
+            STRUCT -> {
+                val thisFields = this.structFields
+                val otherFields = other.structFields
+                when {
+                    thisFields === otherFields -> true
+                    thisFields.size != otherFields.size -> false
+                    // We've tried the inexpensive checks, now do a deep comparison
+                    else -> thisFields.groupingBy { it }.eachCount() == otherFields.groupingBy { it }.eachCount()
+                }
+            }
+            NULL -> TODO("Unreachable")
+        }
+}
+
+/**
+ * Calculates the hash code of an [IonElement].
+ *
+ * Implementations of [IonElement] MAY NOT calculate their own hash codes, but MAY cache the result of this function.
+ */
+public fun hashElement(ionElement: IonElement): Int {
+    val element = ionElement.asAnyElement()
+    val typeAndValueHashCode = if (element.isNull) {
+        element.type.hashCode()
+    } else {
+        // Matching an enum rather than a type allows the Kotlin compiler
+        // to use a tableswitch instead of a chain of if/else comparisons.
+        val valueHashCode = when (element.type) {
+            BOOL -> element.booleanValue.hashCode()
+            INT -> when (element.integerSize) {
+                IntElementSize.LONG -> element.longValue.hashCode()
+                IntElementSize.BIG_INTEGER -> element.bigIntegerValue.hashCode()
+            }
+            // Adding compareTo(0.0) causes 0e0 to have a different hash code than -0e0
+            FLOAT -> element.doubleValue.compareTo(0.0).hashCode() * 31 + element.doubleValue.hashCode()
+            DECIMAL -> element.decimalValue.isNegativeZero.hashCode() * 31 + element.decimalValue.hashCode()
+            TIMESTAMP -> element.timestampValue.hashCode()
+            STRING -> element.textValue.hashCode()
+            SYMBOL -> element.textValue.hashCode()
+            BLOB -> element.bytesValue.hashCode()
+            CLOB -> element.bytesValue.hashCode()
+            LIST -> element.listValues.hashCode()
+            SEXP -> element.sexpValues.hashCode()
+            STRUCT -> element.structFields.map { it.hashCode() }.sorted().hashCode()
+            NULL -> TODO("Unreachable")
+        }
+        element.type.hashCode() * 31 + valueHashCode
+    }
+    return typeAndValueHashCode * 31 + element.annotations.hashCode()
+}
+
+/**
+ * Calculates the hash code of a [StructField].
+ */
+public fun hashField(structField: StructField): Int {
+    return structField.name.hashCode() * 31 + structField.value.hashCode()
+}

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -41,6 +41,9 @@ import java.util.function.Consumer
  * All implementations of [IonElement] implement [Object.equals] and [Object.hashCode] according to the Ion
  * specification.
  *
+ * The hash algorithm is not part of the API and may change. Therefore, any implementations of [IonElement] must call
+ * [hashElement] rather than calculating their own hashcode.
+ *
  * Collections returned from the following properties implement [Object.equals] and [Object.hashCode] according to the
  * requirements of [List<T>], wherein order is significant.
  *
@@ -49,7 +52,7 @@ import java.util.function.Consumer
  * - [ListElement.values]
  * - [SexpElement.values]
  * - [StructElement.values]
-
+ *
  * Be aware that this can yield inconsistent results when working with structs, due to their unordered nature.
  *
  * ```
@@ -95,6 +98,22 @@ public interface IonElement {
 
     /** Converts the current element to Ion text. */
     override fun toString(): String
+
+    /**
+     * Indicates whether some other [IonElement] is "equal to" this one.
+     *
+     * Implementations of [IonElement] must implement this method in such a way that it is consistent with
+     * [areElementsEqual] as well as conforming to the general requirements of [Any.equals].
+     */
+    public override fun equals(other: Any?): Boolean
+
+    /**
+     * Returns a hash code value for an [IonElement].
+     *
+     * In order to fulfill the general contract for [Any.hashCode], implementations of [IonElement] MUST call
+     * [hashElement] rather than calculating their own hash code value.
+     */
+    public override fun hashCode(): Int
 
     /*
      * The following `with*` mutators are repeated on every sub-interface because any approach using generics that is
@@ -165,7 +184,12 @@ public enum class IntElementSize {
 /** Represents an Ion int. */
 public interface IntElement : IonElement {
 
-    /** The size of this [IntElement]. */
+    /**
+     * The size of this [IntElement].
+     *
+     * This indicates the magnitude of the integer, but does not imply a particular in-memory representation.
+     * Two equal [IntElement]s will always return the same [integerSize].
+     */
     public val integerSize: IntElementSize
 
     /**

--- a/src/com/amazon/ionelement/api/MutableStructFields.kt
+++ b/src/com/amazon/ionelement/api/MutableStructFields.kt
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ionelement.api
 
 /**

--- a/src/com/amazon/ionelement/api/StructField.kt
+++ b/src/com/amazon/ionelement/api/StructField.kt
@@ -17,6 +17,9 @@ package com.amazon.ionelement.api
 
 /**
  * A field within an Ion struct.
+ *
+ * This type uses value-based equality—two [StructField]s are equal if their names and values are equal.
+ * All implementations of [StructField] MUST use [hashField] to override [Any.hashCode].
  */
 public interface StructField {
     public val name: String

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -55,9 +55,7 @@ internal class BigIntIntElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as BigIntIntElementImpl
+        if (other !is IntElement) return false
 
         if (bigIntegerValue != other.bigIntegerValue) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -32,10 +32,11 @@ internal class BigIntIntElementImpl(
 
     override val type: ElementType get() = ElementType.INT
 
-    override val integerSize: IntElementSize get() = IntElementSize.BIG_INTEGER
+    override val integerSize: IntElementSize
+        get() = if (bigIntegerValue in RANGE_OF_LONG) IntElementSize.LONG else IntElementSize.BIG_INTEGER
 
     override val longValue: Long get() {
-        if (bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
+        if (integerSize != IntElementSize.LONG) {
             constraintError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
         }
         return bigIntegerValue.longValueExact()
@@ -53,24 +54,8 @@ internal class BigIntIntElementImpl(
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(bigIntegerValue)
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is IntElement) return false
-
-        if (bigIntegerValue != other.bigIntegerValue) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = bigIntegerValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }
 
-internal val MAX_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MAX_VALUE)
-internal val MIN_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MIN_VALUE)
+internal val RANGE_OF_LONG = BigInteger.valueOf(Long.MIN_VALUE)..BigInteger.valueOf(Long.MAX_VALUE)

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -28,6 +28,8 @@ internal class BlobElementImpl(
     override val metas: PersistentMetaContainer
 ) : LobElementBase(bytes), BlobElement {
 
+    override val type: ElementType get() = ElementType.BLOB
+
     override val blobValue: ByteArrayView get() = bytesValue
 
     override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
@@ -42,5 +44,6 @@ internal class BlobElementImpl(
     override fun withMeta(key: String, value: Any): BlobElementImpl = _withMeta(key, value)
     override fun withoutMetas(): BlobElementImpl = _withoutMetas()
 
-    override val type: ElementType get() = ElementType.BLOB
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -42,9 +42,7 @@ internal class BoolElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as BoolElementImpl
+        if (other !is BoolElement) return false
 
         if (booleanValue != other.booleanValue) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -40,21 +40,7 @@ internal class BoolElementImpl(
     override fun withoutMetas(): BoolElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is BoolElement) return false
 
-        if (booleanValue != other.booleanValue) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = booleanValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
+++ b/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
@@ -13,9 +13,10 @@ internal class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is ByteArrayViewImpl) return false
+        if (other !is ByteArrayView) return false
 
-        if (!bytes.contentEquals(other.bytes)) return false
+        val otherBytes = if (other is ByteArrayViewImpl) other.bytes else other.copyOfBytes()
+        if (!bytes.contentEquals(otherBytes)) return false
 
         return true
     }

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -28,6 +28,8 @@ internal class ClobElementImpl(
     override val metas: PersistentMetaContainer
 ) : LobElementBase(bytes), ClobElement {
 
+    override val type: ElementType get() = ElementType.CLOB
+
     override val clobValue: ByteArrayView get() = bytesValue
 
     override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
@@ -41,5 +43,6 @@ internal class ClobElementImpl(
     override fun withMeta(key: String, value: Any): ClobElementImpl = _withMeta(key, value)
     override fun withoutMetas(): ClobElementImpl = _withoutMetas()
 
-    override val type: ElementType get() = ElementType.CLOB
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -43,9 +43,7 @@ internal class DecimalElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as DecimalElementImpl
+        if (other !is DecimalElement) return false
 
         // `==` considers `0d0` and `-0d0` to be equivalent.  `Decimal.equals` does not.
         if (!Decimal.equals(decimalValue, other.decimalValue)) return false

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -41,23 +41,7 @@ internal class DecimalElementImpl(
     override fun withoutMetas(): DecimalElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is DecimalElement) return false
 
-        // `==` considers `0d0` and `-0d0` to be equivalent.  `Decimal.equals` does not.
-        if (!Decimal.equals(decimalValue, other.decimalValue)) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = decimalValue.isNegativeZero.hashCode()
-        result = 31 * result + decimalValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -40,23 +40,7 @@ internal class FloatElementImpl(
     override fun withoutMetas(): FloatElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is FloatElement) return false
 
-        // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
-        if (doubleValue.compareTo(other.doubleValue) != 0) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = doubleValue.compareTo(0.0).hashCode() // <-- causes 0e0 to have a different hash code than -0e0
-        result = 31 * result + doubleValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -42,9 +42,7 @@ internal class FloatElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as FloatElementImpl
+        if (other !is FloatElement) return false
 
         // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
         if (doubleValue.compareTo(other.doubleValue) != 0) return false

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -122,9 +122,9 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
                                         val bigIntValue = ionReader.bigIntegerValue()
                                         // Ion java's IonReader appears to determine integerSize based on number of bits,
                                         // not on the actual value, which means if we have a padded int that is > 63 bits,
-                                        // but who's value only uses <= 63 bits then integerSize is still BIG_INTEGER.
+                                        // but whose value only uses <= 63 bits then integerSize is still BIG_INTEGER.
                                         // Compensate for that here...
-                                        if (bigIntValue > MAX_LONG_AS_BIG_INT || bigIntValue < MIN_LONG_AS_BIG_INT)
+                                        if (bigIntValue !in RANGE_OF_LONG)
                                             ionInt(bigIntValue)
                                         else {
                                             ionInt(ionReader.longValue())

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -42,9 +42,7 @@ internal class ListElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ListElementImpl
+        if (other !is ListElement) return false
 
         if (values != other.values) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -40,22 +40,6 @@ internal class ListElementImpl(
     override fun withMeta(key: String, value: Any): ListElementImpl = _withMeta(key, value)
     override fun withoutMetas(): ListElementImpl = _withoutMetas()
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is ListElement) return false
-
-        if (values != other.values) return false
-        if (annotations != other.annotations) return false
-        // Note: [metas] intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = values.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: [metas] intentionally omitted!
-
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/LobElementBase.kt
+++ b/src/com/amazon/ionelement/impl/LobElementBase.kt
@@ -36,9 +36,9 @@ internal abstract class LobElementBase(
     override fun equals(other: Any?): Boolean {
         return when {
             this === other -> true
-            other !is LobElementBase -> false
+            other !is LobElement -> false
             type != other.type -> false
-            !bytes.contentEquals(other.bytes) -> false
+            bytesValue != other.bytesValue -> false
             annotations != other.annotations -> false
             // Metas are intentionally omitted here.
             else -> true

--- a/src/com/amazon/ionelement/impl/LobElementBase.kt
+++ b/src/com/amazon/ionelement/impl/LobElementBase.kt
@@ -32,24 +32,4 @@ internal abstract class LobElementBase(
     abstract override fun withMetas(additionalMetas: MetaContainer): LobElementBase
     abstract override fun withMeta(key: String, value: Any): LobElementBase
     abstract override fun withoutMetas(): LobElementBase
-
-    override fun equals(other: Any?): Boolean {
-        return when {
-            this === other -> true
-            other !is LobElement -> false
-            type != other.type -> false
-            bytesValue != other.bytesValue -> false
-            annotations != other.annotations -> false
-            // Metas are intentionally omitted here.
-            else -> true
-        }
-    }
-
-    override fun hashCode(): Int {
-        var result = bytes.contentHashCode()
-        result = 31 * result + type.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Metas are intentionally omitted here.
-        return result
-    }
 }

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -44,24 +44,7 @@ internal class LongIntElementImpl(
     override fun withoutMetas(): LongIntElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is IntElement) return false
 
-        when (other.integerSize) {
-            IntElementSize.LONG -> if (longValue != other.longValue) return false
-            IntElementSize.BIG_INTEGER -> if (bigIntegerValue != other.bigIntegerValue) return false
-        }
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = longValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -46,11 +46,12 @@ internal class LongIntElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other !is IntElement) return false
 
-        other as LongIntElementImpl
-
-        if (longValue != other.longValue) return false
+        when (other.integerSize) {
+            IntElementSize.LONG -> if (longValue != other.longValue) return false
+            IntElementSize.BIG_INTEGER -> if (bigIntegerValue != other.bigIntegerValue) return false
+        }
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 

--- a/src/com/amazon/ionelement/impl/MutableStructFieldsImpl.kt
+++ b/src/com/amazon/ionelement/impl/MutableStructFieldsImpl.kt
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ionelement.impl
 
 import com.amazon.ionelement.api.AnyElement

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -42,22 +42,6 @@ internal class NullElementImpl(
 
     override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is IonElement) return false
-
-        if (!other.isNull) return false
-        if (type != other.type) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = type.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -44,10 +44,9 @@ internal class NullElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other !is IonElement) return false
 
-        other as NullElementImpl
-
+        if (!other.isNull) return false
         if (type != other.type) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -42,9 +42,7 @@ internal class SexpElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SexpElementImpl
+        if (other !is SexpElement) return false
 
         if (values != other.values) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -40,21 +40,6 @@ internal class SexpElementImpl(
     override fun withMeta(key: String, value: Any): SexpElementImpl = _withMeta(key, value)
     override fun withoutMetas(): SexpElementImpl = _withoutMetas()
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is SexpElement) return false
-
-        if (values != other.values) return false
-        if (annotations != other.annotations) return false
-        // Note: [metas] intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = values.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: [metas] intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -42,21 +42,7 @@ internal class StringElementImpl(
     override fun withoutMetas(): StringElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is StringElement) return false
 
-        if (textValue != other.textValue) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = textValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -44,9 +44,7 @@ internal class StringElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as StringElementImpl
+        if (other !is StringElement) return false
 
         if (textValue != other.textValue) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/StructFieldImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructFieldImpl.kt
@@ -24,4 +24,17 @@ import com.amazon.ionelement.api.StructField
 internal data class StructFieldImpl(
     override val name: String,
     override val value: AnyElement
-) : StructField
+) : StructField {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is StructField) return false
+        if (name != other.name) return false
+        if (value != other.value) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode() * 31 + value.hashCode()
+    }
+}

--- a/src/com/amazon/ionelement/impl/StructFieldImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructFieldImpl.kt
@@ -15,8 +15,7 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.StructField
+import com.amazon.ionelement.api.*
 
 /**
  * Provides an interface for storing an Ion `struct`'s field and its value.
@@ -34,7 +33,5 @@ internal data class StructFieldImpl(
         return true
     }
 
-    override fun hashCode(): Int {
-        return name.hashCode() * 31 + value.hashCode()
-    }
+    override fun hashCode(): Int = hashField(this)
 }

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -42,21 +42,7 @@ internal class SymbolElementImpl(
     override fun withoutMetas(): SymbolElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is SymbolElement) return false
 
-        if (textValue != other.textValue) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omittted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = textValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omittted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -44,9 +44,7 @@ internal class SymbolElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SymbolElementImpl
+        if (other !is SymbolElement) return false
 
         if (textValue != other.textValue) return false
         if (annotations != other.annotations) return false

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -42,21 +42,6 @@ internal class TimestampElementImpl(
 
     override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(timestampValue)
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is TimestampElement) return false
-
-        if (timestampValue != other.timestampValue) return false
-        if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = timestampValue.hashCode()
-        result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
-        return result
-    }
+    override fun equals(other: Any?): Boolean = isEquivalentTo(other)
+    override fun hashCode(): Int = hashElement(this)
 }

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -44,9 +44,7 @@ internal class TimestampElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as TimestampElementImpl
+        if (other !is TimestampElement) return false
 
         if (timestampValue != other.timestampValue) return false
         if (annotations != other.annotations) return false

--- a/test/com/amazon/ionelement/EquivTestCase.kt
+++ b/test/com/amazon/ionelement/EquivTestCase.kt
@@ -16,6 +16,7 @@
 package com.amazon.ionelement
 
 import com.amazon.ionelement.api.*
+import com.amazon.ionelement.impl.*
 import org.junit.jupiter.api.Assertions
 
 data class EquivTestCase(val left: String, val right: String, val isEquiv: Boolean) {
@@ -30,6 +31,10 @@ data class EquivTestCase(val left: String, val right: String, val isEquiv: Boole
         // (this may need to be revisited in the future)
         Assertions.assertNotEquals(0, leftElement.hashCode())
         Assertions.assertNotEquals(0, rightElement.hashCode())
+
+        // Check hashCode against normative implementation
+        Assertions.assertEquals(hashElement(leftElement), leftElement.hashCode(), "hashCode() does not match normative implementation")
+        Assertions.assertEquals(hashElement(rightElement), rightElement.hashCode(), "hashCode() does not match normative implementation")
 
         // Equivalence should be reflexive
         checkEquivalence(true, leftElement, leftElement)
@@ -60,118 +65,192 @@ data class EquivTestCase(val left: String, val right: String, val isEquiv: Boole
         // Nesting the values within a struct should not change the result
         fun nest(ie: AnyElement) = ionStructOf("nested" to ie)
         checkEquivalence(isEquiv, nest(leftElement), nest(rightElement))
-    }
-
-    private fun checkEquivalence(equiv: Boolean, leftElement: IonElement, rightElement: IonElement) {
-        fun checkIt(first: IonElement, second: IonElement) {
-            if (equiv) {
-                Assertions.assertEquals(first, second, "Elements should be equivalent")
-                Assertions.assertEquals(first.hashCode(), second.hashCode(), "Elements should not be equivalent")
-            } else {
-                Assertions.assertNotEquals(first, second, "Elements should not be equal")
-                // Note that two different [IonElement]s *can* have the same hash code and this might one day
-                // break the build and may necessitate removing the assertion below. However, if it does happen we
-                // should evaluate if the hashing algorithm is sufficient or not since that seems unlikely
-                Assertions.assertNotEquals(first.hashCode(), second.hashCode(), "Elements' hash codes should not be equal")
-            }
-        }
-
-        // Equivalence is symmetric
-        checkIt(leftElement, rightElement)
-        checkIt(rightElement, leftElement)
 
         // Try using a proxy to make sure that equivalence is not tied to a particular implementation.
-        val leftProxy = leftElement.proxy()
-        val rightProxy = rightElement.proxy()
-
+        val leftProxy = leftElement.createProxy()
+        val rightProxy = rightElement.createProxy()
         Assertions.assertEquals(leftElement, leftProxy)
         Assertions.assertEquals(rightProxy, rightElement)
 
-        checkIt(leftElement, rightProxy)
-        checkIt(leftProxy, rightElement)
-        checkIt(leftProxy, rightProxy)
+        // Equivalence should be transitive
+        checkEquivalence(isEquiv, leftElement, rightProxy)
+        checkEquivalence(isEquiv, leftProxy, rightElement)
+        checkEquivalence(isEquiv, leftProxy, rightProxy)
+    }
 
-        // Adding metas to one side should not have any effect
-        checkIt(leftElement, rightElement.withMeta("foo", 123))
-        checkIt(rightElement, leftElement.withMeta("bar", 456))
+    private fun checkEquivalence(equiv: Boolean, first: IonElement, second: IonElement) {
+        if (equiv) {
+            Assertions.assertTrue(areElementsEqual(first, second), "Elements should be equivalent.")
+            Assertions.assertEquals(first, second, "equals() implementation does not match normative equivalence implementation")
+            Assertions.assertEquals(first.hashCode(), second.hashCode(), "Elements' hash codes should be equal")
+        } else {
+            Assertions.assertFalse(areElementsEqual(first, second), "Elements should not be equivalent.")
+            Assertions.assertNotEquals(first, second, "equals() implementation does not match normative equivalence implementation")
+            // Note that two different [IonElement]s *can* have the same hash code and this might one day
+            // break the build and may necessitate removing the assertion below. However, if it does happen we
+            // should evaluate if the hashing algorithm is sufficient or not since that seems unlikely
+            Assertions.assertNotEquals(first.hashCode(), second.hashCode(), "Elements' hash codes should not be equal")
+        }
+    }
+
+    private fun IonElement.createProxy(): AnyElement {
+        return if (isNull) {
+            NullElementProxy(this.asAnyElement())
+        } else when (this) {
+            is BoolElement -> BoolElementProxy(this)
+            is IntElement -> IntElementProxy(this)
+            is FloatElement -> FloatElementProxy(this)
+            is DecimalElement -> DecimalElementProxy(this)
+            is TimestampElement -> TimestampElementProxy(this)
+            is StringElement -> StringElementProxy(this)
+            is SymbolElement -> SymbolElementProxy(this)
+            is BlobElement -> BlobElementProxy(this)
+            is ClobElement -> ClobElementProxy(this)
+            is ListElement -> ListElementProxy(this)
+            is SexpElement -> SexpElementProxy(this)
+            is StructElement -> StructElementProxy(this)
+            else -> TODO("Unreachable")
+        }
     }
 
     /**
-     * Returns an anonymous class that is a proxy for this IonElement.
+     * This is an alternate implementation of the whole `IonElement` hierarchy so that we can test to make sure that the
+     * implementations of equals do not have a hard dependency on any implementation details that could be accessed by
+     * casting to a specific implementation. It's okay to use optimizations if "other" is a specific implementation, but
+     * the result must not change just because "other" is a different implementation of the same interfaces.
+     *
+     * Why don't we use mocks for this? It's because AnyElement and e.g. BoolElement have conflicting method signatures
+     * for e.g. [copy] ("Return types of inherited members are incompatible").
      */
-    private inline fun <reified T : IonElement> T.proxy(): T {
-        val delegate = this
-        return when (delegate) {
-            is BoolElement -> object : BoolElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is IntElement -> object : IntElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is FloatElement -> object : FloatElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is DecimalElement -> object : DecimalElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is TimestampElement -> object : TimestampElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is StringElement -> object : StringElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is SymbolElement -> object : SymbolElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is BlobElement -> object : BlobElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is ClobElement -> object : ClobElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is ListElement -> object : ListElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is SexpElement -> object : SexpElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is StructElement -> object : StructElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            is AnyElement -> object : AnyElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-            else -> object : IonElement by delegate {
-                override fun equals(other: Any?): Boolean = delegate == other
-                override fun hashCode(): Int = delegate.hashCode()
-                override fun toString(): String = "AnonymousProxy($delegate)"
-            }
-        } as T
+    private abstract class AnyElementProxy<T : AnyElementProxy<T>>(open val delegate: IonElement) : AnyElement by delegate as AnyElement
+
+    private class NullElementProxy(override val delegate: AnyElement) : AnyElementProxy<NullElementProxy>(delegate) {
+        override fun copy(annotations: List<String>, metas: MetaContainer): NullElementProxy = NullElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): NullElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): NullElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): NullElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): NullElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): NullElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): NullElementProxy = _withoutMetas()
+    }
+
+    private class BoolElementProxy(override val delegate: BoolElement) : AnyElementProxy<BoolElementProxy>(delegate), BoolElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): BoolElementProxy = BoolElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): BoolElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): BoolElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): BoolElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): BoolElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): BoolElementProxy = _withoutMetas()
+    }
+
+    private class IntElementProxy(override val delegate: IntElement) : AnyElementProxy<IntElementProxy>(delegate), IntElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): IntElementProxy = IntElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): IntElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): IntElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): IntElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): IntElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): IntElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): IntElementProxy = _withoutMetas()
+    }
+
+    private class FloatElementProxy(override val delegate: FloatElement) : AnyElementProxy<FloatElementProxy>(delegate), FloatElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): FloatElementProxy = FloatElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): FloatElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): FloatElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): FloatElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): FloatElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): FloatElementProxy = _withoutMetas()
+    }
+
+    private class DecimalElementProxy(override val delegate: DecimalElement) : AnyElementProxy<DecimalElementProxy>(delegate), DecimalElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElementProxy = DecimalElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): DecimalElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): DecimalElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): DecimalElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): DecimalElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): DecimalElementProxy = _withoutMetas()
+    }
+
+    private class TimestampElementProxy(override val delegate: TimestampElement) : AnyElementProxy<TimestampElementProxy>(delegate), TimestampElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElementProxy = TimestampElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): TimestampElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): TimestampElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): TimestampElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): TimestampElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): TimestampElementProxy = _withoutMetas()
+    }
+
+    private class SymbolElementProxy(override val delegate: SymbolElement) : AnyElementProxy<SymbolElementProxy>(delegate), SymbolElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElementProxy = SymbolElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): SymbolElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): SymbolElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): SymbolElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): SymbolElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): SymbolElementProxy = _withoutMetas()
+    }
+
+    private class StringElementProxy(override val delegate: StringElement) : AnyElementProxy<StringElementProxy>(delegate), StringElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): StringElementProxy = StringElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): StringElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): StringElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): StringElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): StringElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): StringElementProxy = _withoutMetas()
+    }
+
+    private class BlobElementProxy(override val delegate: BlobElement) : AnyElementProxy<BlobElementProxy>(delegate), BlobElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): BlobElementProxy = BlobElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): BlobElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): BlobElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): BlobElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): BlobElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): BlobElementProxy = _withoutMetas()
+    }
+
+    private class ClobElementProxy(override val delegate: ClobElement) : AnyElementProxy<ClobElementProxy>(delegate), ClobElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): ClobElementProxy = ClobElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): ClobElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): ClobElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): ClobElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): ClobElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): ClobElementProxy = _withoutMetas()
+    }
+
+    private class ListElementProxy(override val delegate: ListElement) : AnyElementProxy<ListElementProxy>(delegate), ListElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): ListElementProxy = ListElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): ListElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): ListElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): ListElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): ListElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): ListElementProxy = _withoutMetas()
+    }
+
+    private class SexpElementProxy(override val delegate: SexpElement) : AnyElementProxy<SexpElementProxy>(delegate), SexpElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): SexpElementProxy = SexpElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): SexpElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): SexpElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): SexpElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): SexpElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): SexpElementProxy = _withoutMetas()
+    }
+
+    private class StructElementProxy(override val delegate: StructElement) : AnyElementProxy<StructElementProxy>(delegate), StructElement by delegate {
+        override fun copy(annotations: List<String>, metas: MetaContainer): StructElementProxy = StructElementProxy(delegate.copy(annotations, metas))
+        override fun withAnnotations(vararg additionalAnnotations: String): StructElementProxy = _withAnnotations(*additionalAnnotations)
+        override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElementProxy = _withAnnotations(additionalAnnotations)
+        override fun withoutAnnotations(): StructElementProxy = _withoutAnnotations()
+        override fun withMetas(additionalMetas: MetaContainer): StructElementProxy = _withMetas(additionalMetas)
+        override fun withMeta(key: String, value: Any): StructElementProxy = _withMeta(key, value)
+        override fun withoutMetas(): StructElementProxy = _withoutMetas()
     }
 }

--- a/test/com/amazon/ionelement/EquivTestCase.kt
+++ b/test/com/amazon/ionelement/EquivTestCase.kt
@@ -15,10 +15,7 @@
 
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.createIonElementLoader
-import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.*
 import org.junit.jupiter.api.Assertions
 
 data class EquivTestCase(val left: String, val right: String, val isEquiv: Boolean) {
@@ -83,8 +80,98 @@ data class EquivTestCase(val left: String, val right: String, val isEquiv: Boole
         checkIt(leftElement, rightElement)
         checkIt(rightElement, leftElement)
 
+        // Try using a proxy to make sure that equivalence is not tied to a particular implementation.
+        val leftProxy = leftElement.proxy()
+        val rightProxy = rightElement.proxy()
+
+        Assertions.assertEquals(leftElement, leftProxy)
+        Assertions.assertEquals(rightProxy, rightElement)
+
+        checkIt(leftElement, rightProxy)
+        checkIt(leftProxy, rightElement)
+        checkIt(leftProxy, rightProxy)
+
         // Adding metas to one side should not have any effect
         checkIt(leftElement, rightElement.withMeta("foo", 123))
         checkIt(rightElement, leftElement.withMeta("bar", 456))
+    }
+
+    /**
+     * Returns an anonymous class that is a proxy for this IonElement.
+     */
+    private inline fun <reified T : IonElement> T.proxy(): T {
+        val delegate = this
+        return when (delegate) {
+            is BoolElement -> object : BoolElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is IntElement -> object : IntElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is FloatElement -> object : FloatElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is DecimalElement -> object : DecimalElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is TimestampElement -> object : TimestampElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is StringElement -> object : StringElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is SymbolElement -> object : SymbolElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is BlobElement -> object : BlobElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is ClobElement -> object : ClobElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is ListElement -> object : ListElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is SexpElement -> object : SexpElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is StructElement -> object : StructElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            is AnyElement -> object : AnyElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+            else -> object : IonElement by delegate {
+                override fun equals(other: Any?): Boolean = delegate == other
+                override fun hashCode(): Int = delegate.hashCode()
+                override fun toString(): String = "AnonymousProxy($delegate)"
+            }
+        } as T
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I discovered that all of the `equals()` implementations for `IonElement` implementations check that the class is the same. That would mean that if someone else implemented `IonElement`, two Ion-equivalent values would not be equal.

However, the [README](https://github.com/amazon-ion/ion-element-kotlin/blob/5b9ec917ef7b68ccb51866e86702cac125b97906/README.md#L82-L84) says:

> As long as the behavior is implemented correctly (see the documentation of each interface), the implementations of `IonElement` provided by this library are fully interoperable with user supplied implementations.

I've updated all of the `equals()` implementations to allow other implementations of the public API be potentially equal.

In some cases, I did a little more than just change the type check because some of the `equals()` functions were relying on implementation details rather than fields in the public API.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

