### PR TITLE
Ensure that all empty PersistentLists are the same instance.

### DIFF
--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -21,7 +21,6 @@ import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.constraintError
 import java.math.BigInteger
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class BigIntIntElementImpl(
@@ -42,7 +41,7 @@ internal class BigIntIntElementImpl(
     }
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BigIntIntElementImpl =
-        BigIntIntElementImpl(bigIntegerValue, annotations.toPersistentList(), metas.toPersistentMap())
+        BigIntIntElementImpl(bigIntegerValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): BigIntIntElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): BigIntIntElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class BlobElementImpl(
@@ -33,7 +32,7 @@ internal class BlobElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BlobElementImpl =
-        BlobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+        BlobElementImpl(bytes, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): BlobElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class BoolElementImpl(
@@ -30,7 +29,7 @@ internal class BoolElementImpl(
     override val type: ElementType get() = ElementType.BOOL
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BoolElementImpl =
-        BoolElementImpl(booleanValue, annotations.toPersistentList(), metas.toPersistentMap())
+        BoolElementImpl(booleanValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): BoolElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class ClobElementImpl(
@@ -32,7 +31,7 @@ internal class ClobElementImpl(
 
     override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
     override fun copy(annotations: List<String>, metas: MetaContainer): ClobElementImpl =
-        ClobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+        ClobElementImpl(bytes, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): ClobElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -20,7 +20,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class DecimalElementImpl(
@@ -31,7 +30,7 @@ internal class DecimalElementImpl(
     override val type get() = ElementType.DECIMAL
 
     override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElementImpl =
-        DecimalElementImpl(decimalValue, annotations.toPersistentList(), metas.toPersistentMap())
+        DecimalElementImpl(decimalValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): DecimalElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class FloatElementImpl(
@@ -30,7 +29,7 @@ internal class FloatElementImpl(
     override val type: ElementType get() = ElementType.FLOAT
 
     override fun copy(annotations: List<String>, metas: MetaContainer): FloatElementImpl =
-        FloatElementImpl(doubleValue, annotations.toPersistentList(), metas.toPersistentMap())
+        FloatElementImpl(doubleValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): FloatElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class ListElementImpl(
@@ -31,7 +30,7 @@ internal class ListElementImpl(
     override val listValues: List<AnyElement> get() = values
 
     override fun copy(annotations: List<String>, metas: MetaContainer): ListElementImpl =
-        ListElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+        ListElementImpl(values, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): ListElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -20,7 +20,6 @@ import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import java.math.BigInteger
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class LongIntElementImpl(
@@ -34,7 +33,7 @@ internal class LongIntElementImpl(
     override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(longValue)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): LongIntElementImpl =
-        LongIntElementImpl(longValue, annotations.toPersistentList(), metas.toPersistentMap())
+        LongIntElementImpl(longValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): LongIntElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): LongIntElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class NullElementImpl(
@@ -31,7 +30,7 @@ internal class NullElementImpl(
     override val isNull: Boolean get() = true
 
     override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
-        NullElementImpl(type, annotations.toPersistentList(), metas.toPersistentMap())
+        NullElementImpl(type, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): AnyElement = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): AnyElement = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class SexpElementImpl(
@@ -31,7 +30,7 @@ internal class SexpElementImpl(
     override val sexpValues: List<AnyElement> get() = seqValues
 
     override fun copy(annotations: List<String>, metas: MetaContainer): SexpElementImpl =
-        SexpElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+        SexpElementImpl(values, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): SexpElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class StringElementImpl(
@@ -32,7 +31,7 @@ internal class StringElementImpl(
     override val stringValue: String get() = textValue
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StringElementImpl =
-        StringElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+        StringElementImpl(textValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): StringElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -24,7 +24,6 @@ import java.util.function.Consumer
 import kotlinx.collections.immutable.PersistentCollection
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class StructElementImpl(
@@ -42,7 +41,7 @@ internal class StructElementImpl(
     override val values: Collection<AnyElement>
         get() {
             if (valuesBackingField == null) {
-                valuesBackingField = fields.map { it.value }.toPersistentList()
+                valuesBackingField = fields.mapToEmptyOrPersistentList { it.value }
             }
             return valuesBackingField!!
         }
@@ -61,7 +60,7 @@ internal class StructElementImpl(
                 fieldsByNameBackingField =
                     fields
                         .groupBy { it.name }
-                        .map { structFieldGroup -> structFieldGroup.key to structFieldGroup.value.map { it.value }.toPersistentList() }
+                        .map { structFieldGroup -> structFieldGroup.key to structFieldGroup.value.mapToEmptyOrPersistentList { it.value } }
                         .toMap().toPersistentMap()
             }
             return fieldsByNameBackingField!!
@@ -99,7 +98,7 @@ internal class StructElementImpl(
     override fun containsField(fieldName: String): Boolean = fieldsByName.containsKey(fieldName)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElementImpl =
-        StructElementImpl(allFields, annotations.toPersistentList(), metas.toPersistentMap())
+        StructElementImpl(allFields, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): StructElementImpl = _withAnnotations(*additionalAnnotations)
 

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class SymbolElementImpl(
@@ -32,7 +31,7 @@ internal class SymbolElementImpl(
     override val symbolValue: String get() = textValue
 
     override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElementImpl =
-        SymbolElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+        SymbolElementImpl(textValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): SymbolElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElementImpl = _withAnnotations(additionalAnnotations)

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -20,7 +20,6 @@ import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class TimestampElementImpl(
@@ -31,7 +30,7 @@ internal class TimestampElementImpl(
 
     override val type: ElementType get() = ElementType.TIMESTAMP
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElementImpl =
-        TimestampElementImpl(timestampValue, annotations.toPersistentList(), metas.toPersistentMap())
+        TimestampElementImpl(timestampValue, annotations.toEmptyOrPersistentList(), metas.toPersistentMap())
 
     override fun withAnnotations(vararg additionalAnnotations: String): TimestampElementImpl = _withAnnotations(*additionalAnnotations)
     override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElementImpl = _withAnnotations(additionalAnnotations)


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

There's a problem in `kotlinx.collections.immutable` (described in https://github.com/Kotlin/kotlinx.collections.immutable/pull/176) that was causing `ion-element-kotlin` to unnecessarily allocate large numbers of empty lists for unannotated values (and anywhere else that had a possibly-empty list).

Unfortunately, we won't be able to use the fix from that PR until we can update `ion-element-kotlin` to Kotlin >= 1.9.
This adds our own extension functions to work around the bug.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

