### PR TITLE
Fix broken publishing tasks in build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ tasks {
 
     sourcesJar = create<Jar>("sourcesJar") sourcesJar@{
         archiveClassifier.set("sources")
-        from(sourceSets.named("main"))
+        from(sourceSets.main.get().allSource)
     }
 
     javadocJar = create<Jar>("javadocJar") javadocJar@{
@@ -105,8 +105,9 @@ tasks {
 }
 
 publishing {
-    publications.create<MavenPublication>("ion-element") {
-        // from(components.java)
+    publications.create<MavenPublication>("IonElement") {
+        artifactId = "ion-element"
+        artifact(tasks.jar)
         artifact(sourcesJar)
         artifact(javadocJar)
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I tried publishing to maven local, and ran into a few issues. The artifacts had the wrong name, the source artifact task had a runtime failure, and the actual library jar wasn't being published. This fixes all of those things.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

