### PR TITLE
Loader rewrite

### DIFF
--- a/src/main/kotlin/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/main/kotlin/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -24,8 +24,6 @@ import com.amazon.ion.SpanProvider
 import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
 import com.amazon.ionelement.api.*
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentMap
 
 internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {

--- a/src/main/kotlin/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/main/kotlin/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -24,6 +24,9 @@ import com.amazon.ion.SpanProvider
 import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
 import com.amazon.ionelement.api.*
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {
 
@@ -59,9 +62,7 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
         }
 
     override fun loadSingleElement(ionText: String): AnyElement =
-        IonReaderBuilder.standard().build(ionText).use { ionReader ->
-            loadSingleElement(ionReader)
-        }
+        IonReaderBuilder.standard().build(ionText).use(::loadSingleElement)
 
     override fun loadSingleElement(ionReader: IonReader): AnyElement {
         return handleReaderException(ionReader) {
@@ -75,28 +76,22 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
 
     override fun loadAllElements(ionReader: IonReader): List<AnyElement> {
         return handleReaderException(ionReader) {
-            mutableListOf<AnyElement>().also { fields ->
-                ionReader.forEachValue { fields.add(loadCurrentElement(ionReader)) }
+            val elements = mutableListOf<AnyElement>()
+            while (ionReader.next() != null) {
+                elements.add(loadCurrentElement(ionReader))
             }
+            elements
         }
     }
 
     override fun loadAllElements(ionText: String): List<AnyElement> =
-        IonReaderBuilder.standard().build(ionText).use { ionReader ->
-            return ArrayList<AnyElement>().also { list ->
-                ionReader.forEachValue {
-                    list.add(loadCurrentElement(ionReader))
-                }
-            }.toList()
-        }
+        IonReaderBuilder.standard().build(ionText).use(::loadAllElements)
 
     override fun loadCurrentElement(ionReader: IonReader): AnyElement {
         return handleReaderException(ionReader) {
-            require(ionReader.type != null) { "The IonReader was not positioned at an element." }
+            val valueType = requireNotNull(ionReader.type) { "The IonReader was not positioned at an element." }
 
-            val valueType = ionReader.type
-
-            val annotations = ionReader.typeAnnotations!!
+            val annotations = ionReader.typeAnnotations!!.asList().toEmptyOrPersistentList()
 
             val metas = when {
                 options.includeLocationMeta -> {
@@ -107,83 +102,67 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
                     }
                 }
                 else -> emptyMetaContainer()
-            }
+            }.toPersistentMap()
 
-            var element: AnyElement = when {
-                ionReader.type == IonType.DATAGRAM -> error("IonElementLoaderImpl does not know what to do with IonType.DATAGRAM")
-                ionReader.isNullValue -> ionNull(valueType.toElementType())
-                else -> {
-                    when {
-                        !IonType.isContainer(valueType) -> {
-                            when (valueType) {
-                                IonType.BOOL -> ionBool(ionReader.booleanValue())
-                                IonType.INT -> when (ionReader.integerSize!!) {
-                                    IntegerSize.BIG_INTEGER -> {
-                                        val bigIntValue = ionReader.bigIntegerValue()
-                                        // Ion java's IonReader appears to determine integerSize based on number of bits,
-                                        // not on the actual value, which means if we have a padded int that is > 63 bits,
-                                        // but whose value only uses <= 63 bits then integerSize is still BIG_INTEGER.
-                                        // Compensate for that here...
-                                        if (bigIntValue !in RANGE_OF_LONG)
-                                            ionInt(bigIntValue)
-                                        else {
-                                            ionInt(ionReader.longValue())
-                                        }
-                                    }
-                                    IntegerSize.LONG, IntegerSize.INT -> ionInt(ionReader.longValue())
-                                }
-                                IonType.FLOAT -> ionFloat(ionReader.doubleValue())
-                                IonType.DECIMAL -> ionDecimal(ionReader.decimalValue())
-                                IonType.TIMESTAMP -> ionTimestamp(ionReader.timestampValue())
-                                IonType.STRING -> ionString(ionReader.stringValue())
-                                IonType.SYMBOL -> ionSymbol(ionReader.stringValue())
-                                IonType.CLOB -> ionClob(ionReader.newBytes())
-                                IonType.BLOB -> ionBlob(ionReader.newBytes())
-                                else ->
-                                    error("Unexpected Ion type for scalar Ion data type ${ionReader.type}.")
+            if (ionReader.isNullValue) {
+                ionNull(valueType.toElementType(), annotations, metas)
+            } else {
+                when (valueType) {
+                    IonType.BOOL -> BoolElementImpl(ionReader.booleanValue(), annotations, metas)
+                    IonType.INT -> when (ionReader.integerSize!!) {
+                        IntegerSize.BIG_INTEGER -> {
+                            val bigIntValue = ionReader.bigIntegerValue()
+                            // Ion java's IonReader appears to determine integerSize based on number of bits,
+                            // not on the actual value, which means if we have a padded int that is > 63 bits,
+                            // but whose value only uses <= 63 bits then integerSize is still BIG_INTEGER.
+                            // Compensate for that here...
+                            if (bigIntValue !in RANGE_OF_LONG)
+                                BigIntIntElementImpl(bigIntValue, annotations, metas)
+                            else {
+                                LongIntElementImpl(ionReader.longValue(), annotations, metas)
                             }
                         }
-                        else -> {
-                            ionReader.stepIn()
-                            when (valueType) {
-                                IonType.LIST -> {
-                                    ionListOf(loadAllElements(ionReader))
-                                }
-                                IonType.SEXP -> {
-                                    ionSexpOf(loadAllElements(ionReader))
-                                }
-                                IonType.STRUCT -> {
-                                    val fields = mutableListOf<StructField>()
-                                    ionReader.forEachValue { fields.add(StructFieldImpl(ionReader.fieldName, loadCurrentElement(ionReader))) }
-                                    ionStructOf(fields)
-                                }
-                                else -> error("Unexpected Ion type for container Ion data type ${ionReader.type}.")
-                            }.also {
-                                ionReader.stepOut()
-                            }
-                        }
+                        IntegerSize.LONG,
+                        IntegerSize.INT -> LongIntElementImpl(ionReader.longValue(), annotations, metas)
                     }
+
+                    IonType.FLOAT -> FloatElementImpl(ionReader.doubleValue(), annotations, metas)
+                    IonType.DECIMAL -> DecimalElementImpl(ionReader.decimalValue(), annotations, metas)
+                    IonType.TIMESTAMP -> TimestampElementImpl(ionReader.timestampValue(), annotations, metas)
+                    IonType.STRING -> StringElementImpl(ionReader.stringValue(), annotations, metas)
+                    IonType.SYMBOL -> SymbolElementImpl(ionReader.stringValue(), annotations, metas)
+                    IonType.CLOB -> ClobElementImpl(ionReader.newBytes(), annotations, metas)
+                    IonType.BLOB -> BlobElementImpl(ionReader.newBytes(), annotations, metas)
+                    IonType.LIST -> {
+                        ionReader.stepIn()
+                        val list = ListElementImpl(loadAllElements(ionReader).toEmptyOrPersistentList(), annotations, metas)
+                        ionReader.stepOut()
+                        list
+                    }
+                    IonType.SEXP -> {
+                        ionReader.stepIn()
+                        val sexp = SexpElementImpl(loadAllElements(ionReader).toEmptyOrPersistentList(), annotations, metas)
+                        ionReader.stepOut()
+                        sexp
+                    }
+                    IonType.STRUCT -> {
+                        val fields = mutableListOf<StructField>()
+                        ionReader.stepIn()
+                        while (ionReader.next() != null) {
+                            fields.add(
+                                StructFieldImpl(
+                                    ionReader.fieldName,
+                                    loadCurrentElement(ionReader)
+                                )
+                            )
+                        }
+                        ionReader.stepOut()
+                        StructElementImpl(fields.toEmptyOrPersistentList(), annotations, metas)
+                    }
+                    IonType.DATAGRAM -> error("IonElementLoaderImpl does not know what to do with IonType.DATAGRAM")
+                    IonType.NULL -> error("IonType.NULL branch should be unreachable")
                 }
             }.asAnyElement()
-
-            if (annotations.any()) {
-                element = element._withAnnotations(*annotations)
-            }
-            if (metas.any()) {
-                element = element._withMetas(metas)
-            }
-
-            element
         }
-    }
-}
-
-/**
- * Calls [IonReader.next] and invokes [block] until all values at the current level in the [IonReader]
- * have been exhausted.
- * */
-private fun <T> IonReader.forEachValue(block: () -> T) {
-    while (this.next() != null) {
-        block()
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None. However, an offline discussion with someone who was trying out `IonElement` indicated that loading all values as `IonElement` was allocating up to 4x as memory as compared to loading the equivalent data as `IonValue`.

**Description of changes:**

This rewrites the `loadCurrentElement` function to eliminate some unnecessary allocations, and minimize the amount of branching in this function. The result is a very modest memory improvement, but a fairly decent speed improvement, and the size of the compiled bytecode of the rewritten function is about 40% of that of the current version of the function.

**Performance testing results**

Using arbitrary data that I put together from a few different sources (~5kB)

API       | Time (ms/op)                   | gc.alloc.rate.norm (B/op)
----------|-------------------------:|-----------------------------:
IonValue  | `0.053 ± 0.001` |  `81128.034 ± 0.004`
IonElement 1.2.0  | `0.047 ± 0.001` | `215416.030 ± 0.004`
ion-element-kotlin#100  | `0.032 ± 0.001` | `131720.020 ± 0.003`

Ion binary application log file (~20 MB)

API            | Time (ms/op)                    | gc.alloc.rate.norm (B/op)
---------------|-------------------------:|-----------------------------:
IonValue       | `635.450 ±  75.384` |  `625408257.218 ±  49.211`
IonElement 1.2.0    | `630.640 ± 215.099` | `2348935671.047 ± 146.942`
ion-element-kotlin#100 | `452.451 ± 283.069` | `2245469209.217 ± 113.536`

Sample catalog data (~40 kB)

API            | Time (ms/op)               | gc.alloc.rate.norm (B/op)
---------------|---------------------:|------------------------------:
IonValue       | `0.616 ± 0.093` |  `696584.433 ± 0.297`
IonElement 1.2.0    | `0.559 ± 0.028`  | `2999688.359 ± 0.046`
ion-element-kotlin#100 | `0.513 ± 0.007` | `2854072.329 ± 0.041`


This was not as much of an improvement as I had hoped, but I will be following up this PR with another change that is orthogonal to this that should have a more significant impact on the memory allocation rate.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

