### PR TITLE
Make `loadAllElements` fall back to an iterative implementation once a certain depth is reached

### DIFF
--- a/src/main/kotlin/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/main/kotlin/com/amazon/ionelement/api/IonUtils.kt
@@ -42,6 +42,8 @@ public fun IonElement.toIonValue(factory: ValueFactory): IonValue {
  * Bridge function that converts from the mutable [IonValue] to an [AnyElement].
  *
  * New code that does not need to integrate with uses of the mutable DOM should not use this.
+ *
+ * This will fail for IonDatagram if the IonDatagram does not contain exactly one user value.
  */
 public fun IonValue.toIonElement(): AnyElement =
     this.system.newReader(this).use { reader ->

--- a/src/main/kotlin/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/main/kotlin/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -31,7 +31,7 @@ internal class StructElementImpl(
 ) : AnyElementBase(), StructElement {
 
     override val type: ElementType get() = ElementType.STRUCT
-    override val size = allFields.size
+    override val size: Int get() = allFields.size
 
     // Note that we are not using `by lazy` here because it requires 2 additional allocations and
     // has been demonstrated to significantly increase memory consumption!

--- a/src/test/kotlin/com/amazon/ionelement/IonElementLoaderTests.kt
+++ b/src/test/kotlin/com/amazon/ionelement/IonElementLoaderTests.kt
@@ -15,12 +15,17 @@
 
 package com.amazon.ionelement
 
+import com.amazon.ion.Decimal
+import com.amazon.ion.system.IonReaderBuilder
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.util.INCLUDE_LOCATION_META
 import com.amazon.ionelement.util.ION
 import com.amazon.ionelement.util.IonElementLoaderTestCase
 import com.amazon.ionelement.util.convertToString
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -45,6 +50,8 @@ class IonElementLoaderTests {
         // Converting from IonValue to IonElement should result in an IonElement that is equivalent to the
         // parsed IonElement
         assertEquals(parsedIonValue.toIonElement(), parsedIonElement)
+
+        assertEquals(tc.expectedElement, parsedIonElement)
     }
 
     companion object {
@@ -57,15 +64,29 @@ class IonElementLoaderTests {
 
             IonElementLoaderTestCase("1", ionInt(1)),
 
-            IonElementLoaderTestCase("existence::42", ionInt(1).withAnnotations("existence")),
+            IonElementLoaderTestCase("9223372036854775807", ionInt(Long.MAX_VALUE)),
 
-            IonElementLoaderTestCase("\"some string\"", ionString("some string")),
+            IonElementLoaderTestCase("9223372036854775808", ionInt(BigInteger.valueOf(Long.MAX_VALUE) + BigInteger.ONE)),
+
+            IonElementLoaderTestCase("existence::42", ionInt(42).withAnnotations("existence")),
+
+            IonElementLoaderTestCase("0.", ionDecimal(Decimal.ZERO)),
+
+            IonElementLoaderTestCase("1e0", ionFloat(1.0)),
 
             IonElementLoaderTestCase("2019-10-30T04:23:59Z", ionTimestamp("2019-10-30T04:23:59Z")),
 
+            IonElementLoaderTestCase("\"some string\"", ionString("some string")),
+
+            IonElementLoaderTestCase("'some symbol'", ionSymbol("some symbol")),
+
+            IonElementLoaderTestCase("{{\"some clob\"}}", ionClob("some clob".encodeToByteArray())),
+
+            IonElementLoaderTestCase("{{ }}", ionBlob(byteArrayOf())),
+
             IonElementLoaderTestCase("[1, 2, 3]", ionListOf(ionInt(1), ionInt(2), ionInt(3))),
 
-            IonElementLoaderTestCase("(1 2 3)", ionListOf(ionInt(1), ionInt(2), ionInt(3))),
+            IonElementLoaderTestCase("(1 2 3)", ionSexpOf(ionInt(1), ionInt(2), ionInt(3))),
 
             IonElementLoaderTestCase(
                 "{ foo: 1, bar: 2, bat: 3 }",
@@ -74,7 +95,79 @@ class IonElementLoaderTests {
                     "bar" to ionInt(2),
                     "bat" to ionInt(3)
                 )
-            )
+            ),
+
+            // Nested container cases
+            IonElementLoaderTestCase("((null.list))", ionSexpOf(ionSexpOf(ionNull(ElementType.LIST)))),
+            IonElementLoaderTestCase("(1 (2 3))", ionSexpOf(ionInt(1), ionSexpOf(ionInt(2), ionInt(3)))),
+            IonElementLoaderTestCase("{foo:[1]}", ionStructOf("foo" to ionListOf(ionInt(1)))),
+            IonElementLoaderTestCase("[{foo:1}]", ionListOf(ionStructOf("foo" to ionInt(1)))),
+            IonElementLoaderTestCase("{foo:{bar:1}}", ionStructOf("foo" to ionStructOf("bar" to ionInt(1)))),
+            IonElementLoaderTestCase("{foo:[{}]}", ionStructOf("foo" to ionListOf(ionStructOf(emptyList())))),
+            IonElementLoaderTestCase("[{}]", ionListOf(ionStructOf(emptyList()))),
+            IonElementLoaderTestCase("[{}, {}]", ionListOf(ionStructOf(emptyList()), ionStructOf(emptyList()))),
+            IonElementLoaderTestCase("[{foo:1, bar: 2}]", ionListOf(ionStructOf("foo" to ionInt(1), "bar" to ionInt(2)))),
+            IonElementLoaderTestCase(
+                "{foo:[{bar:({})}]}",
+                ionStructOf("foo" to ionListOf(ionStructOf("bar" to ionSexpOf(ionStructOf(emptyList())))))
+            ),
         )
+    }
+
+    @Test
+    fun `regardless of depth, no StackOverflowError is thrown`() {
+        // Throws StackOverflowError in ion-element@v1.2.0 and prior versions when there's ~4k nested containers
+        // Run for every container type to ensure that they all correctly fall back to the iterative impl.
+
+        val listData = "[".repeat(999999) + "]".repeat(999999)
+        loadAllElements(listData)
+
+        val sexpData = "(".repeat(999999) + ")".repeat(999999)
+        loadAllElements(sexpData)
+
+        val structData = "{a:".repeat(999999) + "b" + "}".repeat(999999)
+        loadAllElements(structData)
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForDemoTest")
+    fun `deeply nested values should be loaded correctly`(tc: IonElementLoaderTestCase) {
+        // Wrap everything in many layers of Ion lists so that we can be sure to trigger the iterative fallback.
+        val nestingLevels = 500
+        val textIon = "[".repeat(nestingLevels) + tc.textIon + "]".repeat(nestingLevels)
+        var expectedElement = tc.expectedElement
+        repeat(nestingLevels) { expectedElement = ionListOf(expectedElement) }
+
+        val parsedIonValue = ION.singleValue(textIon)
+        val parsedIonElement = loadSingleElement(textIon, INCLUDE_LOCATION_META)
+
+        // Text generated from both should match
+        assertEquals(convertToString(parsedIonValue), parsedIonElement.toString())
+
+        // Converting from IonElement to IonValue results in an IonValue that is equivalent to the parsed IonValue
+        assertEquals(parsedIonElement.toIonValue(ION), parsedIonValue)
+
+        // Converting from IonValue to IonElement should result in an IonElement that is equivalent to the
+        // parsed IonElement
+        assertEquals(parsedIonValue.toIonElement(), parsedIonElement)
+
+        assertEquals(expectedElement, parsedIonElement)
+    }
+
+    @Test
+    fun `loadCurrentElement throws exception when not positioned on a value`() {
+        val reader = IonReaderBuilder.standard().build("foo")
+        // We do not advance to the first value in the reader.
+        assertThrows<IllegalArgumentException> { loadCurrentElement(reader) }
+    }
+
+    @Test
+    fun `loadSingleElement throws exception when no values in reader`() {
+        assertThrows<IllegalArgumentException> { loadSingleElement("") }
+    }
+
+    @Test
+    fun `loadSingleElement throws exception when more than one values in reader`() {
+        assertThrows<IllegalArgumentException> { loadSingleElement("a b") }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This ensures that we cannot get a `StackOverflowException` by loading data that has very deeply nested containers.

I started out with a purely iterative approach, but I discovered that it introduced a performance regression for some of my sample data, so instead, I made it use the existing recursive approach with a fallback to the iterative approach once the `IonReader` reaches a certain depth of nested containers. (In this case, I've selected 100 as an arbitrary-ish value that ought to be good enough to use recursion for most use cases.)

I also noticed that some of my test data had a slight performance _improvement_ using the iterative approach, so I think that we should add an iterative vs recursive flag to the `IonElementLoaderOptions` class. However, it's not straightforward to do so because it has the potential to be a breaking change if done incorrectly, so I want to defer that for a future PR.

**Performance**

* "IonValue" is a comparison with the latest release of `ion-java`.
* "Baseline" is the current tip of `master`.
* "MAX_DEPTH=100" is the implementation in this PR.
* "MAX_DEPTH=0" is the implementation in this PR _if_ the `MAX_RECURSION_DEPTH` constant is set to 0 (i.e. immediately fall back to the iterative implementation).

There is a slight performance regression, but I believe that it is acceptable in order to prevent `StackOverflowError`s from occurring. A purely iterative approach is faster for some data, which is why I plan to make it configurable.

Composition of some arbitrary data (~5kb)

Condition     | Time (ms/op)    | gc.alloc.rate.norm (B/op)
--------------|----------------:|------------------------:
IonValue      | `0.053 ± 0.001` | `81128.034 ± 0.004`
Baseline      | `0.023 ± 0.001` | `54856.014 ± 0.002`
MAX_DEPTH=100 | `0.025 ± 0.001` | `54832.016 ± 0.002`
MAX_DEPTH=0   | `0.027 ± 0.001` | `55912.018 ± 0.002`

Sample binary Ion application logs (~20MB)
Condition     | Time (ms/op)       | gc.alloc.rate.norm (B/op)
--------------|-------------------:|------------------------:
IonValue      | `635.450 ± 75.384` | `625408257.218 ± 49.211`
Baseline      | `286.219 ± 28.832` | `449205604.132 ± 17.491`
MAX_DEPTH=100 | `295.489 ± 32.007` | `449205608.339 ± 23.524`
MAX_DEPTH=0   | `310.604 ± 22.694` | `454411169.864 ± 13.729`

Sample product catalog data (~40kb)
Condition      | Time (ms/op)    | gc.alloc.rate.norm (B/op)
---------------|----------------:|------------------------:
IonValue       | `0.616 ± 0.093` | `696584.433 ± 0.297`
Baseline       | `0.310 ± 0.006` | `632136.199 ± 0.023`
MAX_DEPTH=100  | `0.315 ± 0.004` | `632080.202 ± 0.026`
MAX_DEPTH=0    | `0.284 ± 0.003` | `632968.182 ± 0.022`


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

