### PR TITLE
Adds loader option to use iterative-only loading

### DIFF
--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -388,16 +388,37 @@ public final class com/amazon/ionelement/api/IonElementLoaderException : com/ama
 }
 
 public final class com/amazon/ionelement/api/IonElementLoaderOptions {
+	public static final field Companion Lcom/amazon/ionelement/api/IonElementLoaderOptions$Companion;
 	public fun <init> ()V
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun builder ()Lcom/amazon/ionelement/api/IonElementLoaderOptions$Builder;
 	public final fun component1 ()Z
+	public final fun copy ()Lcom/amazon/ionelement/api/IonElementLoaderOptions;
 	public final fun copy (Z)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
 	public static synthetic fun copy$default (Lcom/amazon/ionelement/api/IonElementLoaderOptions;ZILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
+	public final synthetic fun copyWith (Lkotlin/jvm/functions/Function1;)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIncludeLocationMeta ()Z
+	public final fun getUseRecursiveLoad ()Z
 	public fun hashCode ()I
+	public final fun toBuilder ()Lcom/amazon/ionelement/api/IonElementLoaderOptions$Builder;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amazon/ionelement/api/IonElementLoaderOptions$Builder {
+	public final fun build ()Lcom/amazon/ionelement/api/IonElementLoaderOptions;
+	public final fun getIncludeLocationMeta ()Z
+	public final fun getUseRecursiveLoad ()Z
+	public final synthetic fun setIncludeLocationMeta (Z)V
+	public final synthetic fun setUseRecursiveLoad (Z)V
+	public final fun withIncludeLocationMeta (Z)Lcom/amazon/ionelement/api/IonElementLoaderOptions$Builder;
+	public final fun withUseRecursiveLoad (Z)Lcom/amazon/ionelement/api/IonElementLoaderOptions$Builder;
+}
+
+public final class com/amazon/ionelement/api/IonElementLoaderOptions$Companion {
+	public final fun builder ()Lcom/amazon/ionelement/api/IonElementLoaderOptions$Builder;
+	public final synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
 }
 
 public abstract class com/amazon/ionelement/api/IonLocation {

--- a/src/main/kotlin/com/amazon/ionelement/api/IonElementLoader.kt
+++ b/src/main/kotlin/com/amazon/ionelement/api/IonElementLoader.kt
@@ -76,17 +76,145 @@ public interface IonElementLoader {
 /**
  * Specifies options for [IonElementLoader].
  *
- * While there is only one property here currently, new properties may be added to this class without breaking
- * source compatibility with prior versions of this library.
+ * Java consumers must use [IonElementLoaderOptions.builder] to create an instance of [IonElementLoaderOptions].
+ * ```java
+ * IonElementLoaderOptions loaderOpts = IonElementLoaderOptions.builder()
+ *     .withIncludeLocationMetadata(true)
+ *     .build();
+ * ```
+ * When calling from Kotlin, [IonElementLoaderOptions.invoke] is also available.
+ * ```kotlin
+ * val loaderOpts = IonElementLoaderOptions {
+ *     includeLocationMetadata = true
+ * }
+ * ```
  */
-public data class IonElementLoaderOptions(
-    /**
-     * Set to true to cause `IonLocation` to be stored in the [IonElement.metas] collection of all elements loaded.
+public class IonElementLoaderOptions internal constructor(
+    val includeLocationMeta: Boolean,
+    val useRecursiveLoad: Boolean,
+) {
+    /*
+     * Intentionally not a KDoc comment.
      *
-     * This is `false` by default because it has a performance penalty.
+     * IonElementLoaderOptions used to be a data class, but data classes have some inherent backwards compatibility
+     * issues. Namely, that the auto-generated `copy` function does not have Java overloads with lesser numbers of
+     * parameters.
+     *
+     * The `copy()` and `component1()` functions and the single arg constructor in this class exist for backwards
+     * compatibility. They should be removed in the next major version.
      */
-    val includeLocationMeta: Boolean = false
-)
+
+    @Deprecated("Will be removed in the next major version. Replace with builder.")
+    @JvmOverloads
+    constructor(includeLocationMeta: Boolean = false) : this(includeLocationMeta, DEFAULT.useRecursiveLoad)
+
+    @Deprecated("Will be removed in the next major version. Use toBuilder() to copy this to a new builder.")
+    @JvmOverloads
+    fun copy(includeLocationMeta: Boolean = this.includeLocationMeta): IonElementLoaderOptions {
+        return IonElementLoaderOptions(includeLocationMeta, useRecursiveLoad)
+    }
+
+    @Deprecated("Will be removed in the next major version. Replace with getIncludeLocationMetadata().")
+    public operator fun component1() = includeLocationMeta
+
+    /**
+     * Returns a new [Builder] that is prepopulated with the values in this [IonElementLoaderOptions].
+     */
+    fun toBuilder(): Builder = Builder(this)
+
+    /**
+     * Creates a new copy of this [IonElementLoaderOptions] with the given changes.
+     */
+    @JvmSynthetic
+    fun copyWith(block: Builder.() -> Unit) = toBuilder().apply(block).build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IonElementLoaderOptions) return false
+        return includeLocationMeta == other.includeLocationMeta &&
+            useRecursiveLoad == other.useRecursiveLoad
+    }
+
+    override fun hashCode(): Int {
+        // We can treat all the boolean options as flags in a bitfield to guarantee no hash collisions.
+        return (if (includeLocationMeta) 1 else 0) +
+            (if (useRecursiveLoad) 2 else 0)
+    }
+
+    override fun toString(): String {
+        return "IonElementLoaderOptions(" +
+            "includeLocationMeta=$includeLocationMeta," +
+            "useRecursiveLoad=$useRecursiveLoad," +
+            ")"
+    }
+
+    companion object {
+        @JvmStatic
+        private val DEFAULT = IonElementLoaderOptions(
+            includeLocationMeta = false,
+            useRecursiveLoad = true,
+        )
+
+        @JvmStatic
+        fun builder() = Builder(DEFAULT)
+
+        @JvmSynthetic
+        operator fun invoke(block: Builder.() -> Unit): IonElementLoaderOptions {
+            return builder().apply(block).build()
+        }
+    }
+
+    /*
+     * Implementation Note:
+     * This builder includes `with*` methods for idiomatic usage from Java, and the properties have their setters marked
+     * with `@JvmSynthetic` rather than private so that they are visible from Kotlin for a DSL-like experience.
+     */
+    class Builder internal constructor(startingValues: IonElementLoaderOptions) {
+        /**
+         * Set to `true` to cause `IonLocation` to be stored in the [IonElement.metas] collection of all elements loaded.
+         *
+         * This is `false` by default because it has a performance penalty.
+         */
+        var includeLocationMeta: Boolean = startingValues.includeLocationMeta
+            @JvmSynthetic set
+
+        /**
+         * Set to `false` to cause the [IonElementLoader] to use an iterative loader. Otherwise, the loader will use a
+         * recursive approach and fall back to the iterative loader if it steps into nested containers with a depth greater
+         * than 100.
+         *
+         * This is `true` by default.
+         *
+         * This does not affect the behavior of the [IonElementLoader] other than its performance characteristics. If
+         * performance is critical, users should benchmark both options for loading typical data and select the one with
+         * the desired performance characteristics.
+         */
+        var useRecursiveLoad: Boolean = startingValues.useRecursiveLoad
+            @JvmSynthetic set
+
+        /**
+         * Set to `true` to cause `IonLocation` to be stored in the [IonElement.metas] collection of all elements loaded.
+         *
+         * This is `false` by default because it has a performance penalty.
+         */
+        fun withIncludeLocationMeta(value: Boolean) = apply { includeLocationMeta = value }
+
+        /**
+         * Set to `false` to cause the [IonElementLoader] to use an iterative loader. Otherwise, the loader will use a
+         * recursive approach and fall back to the iterative loader if it steps into nested containers with a depth greater
+         * than 100.
+         *
+         * This is `true` by default.
+         *
+         * This does not affect the behavior of the [IonElementLoader] other than its performance characteristics. If
+         * performance is critical, users should benchmark both options for loading typical data and select the one with
+         * the desired performance characteristics.
+         */
+        fun withUseRecursiveLoad(value: Boolean) = apply { useRecursiveLoad = value }
+
+        fun build() = IonElementLoaderOptions(includeLocationMeta, useRecursiveLoad)
+    }
+}
 
 /** Creates an [IonElementLoader] implementation with the specified [options]. */
 @JvmOverloads

--- a/src/test/java/com/amazon/ionelement/demos/ElementLoaderDemo.java
+++ b/src/test/java/com/amazon/ionelement/demos/ElementLoaderDemo.java
@@ -3,6 +3,7 @@ package com.amazon.ionelement.demos;
 import com.amazon.ion.IonReader;
 import com.amazon.ionelement.api.AnyElement;
 import com.amazon.ionelement.api.ElementLoader;
+import com.amazon.ionelement.api.IonElementLoaderOptions;
 import com.amazon.ionelement.util.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,26 @@ import java.util.Iterator;
 public class ElementLoaderDemo extends DemoBase {
     private static final String ION_TEXT_STRUCT = "{ a_field: \"hello!\"}";
     private static final String ION_TEXT_MULTIPLE_VALUES = "1 2 3";
+
+    @Test
+    void createIonElementLoaderOptions() {
+        IonElementLoaderOptions opts = IonElementLoaderOptions.builder()
+            .withIncludeLocationMeta(true)
+            .withUseRecursiveLoad(false)
+            .build();
+
+        assertTrue(opts.getIncludeLocationMeta());
+        assertFalse(opts.getUseRecursiveLoad());
+
+        IonElementLoaderOptions copy = opts.toBuilder()
+            .withUseRecursiveLoad(true)
+            .build();
+
+        // Unchanged
+        assertTrue(copy.getIncludeLocationMeta());
+        // Changed
+        assertTrue(copy.getUseRecursiveLoad());
+    }
 
     @Test
     void loadSingleElement_text() {

--- a/src/test/kotlin/com/amazon/ionelement/IonElementLoaderTests.kt
+++ b/src/test/kotlin/com/amazon/ionelement/IonElementLoaderTests.kt
@@ -24,6 +24,8 @@ import com.amazon.ionelement.util.IonElementLoaderTestCase
 import com.amazon.ionelement.util.convertToString
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -169,5 +171,25 @@ class IonElementLoaderTests {
     @Test
     fun `loadSingleElement throws exception when more than one values in reader`() {
         assertThrows<IllegalArgumentException> { loadSingleElement("a b") }
+    }
+
+    @Test
+    fun `create an IonElementLoaderOptions instance`() {
+        val opts = IonElementLoaderOptions {
+            includeLocationMeta = true
+            useRecursiveLoad = false
+        }
+
+        assertTrue(opts.includeLocationMeta)
+        assertFalse(opts.useRecursiveLoad)
+
+        val copy = opts.copyWith {
+            useRecursiveLoad = true
+        }
+
+        // Unchanged
+        assertTrue(copy.includeLocationMeta)
+        // Changed
+        assertTrue(copy.useRecursiveLoad)
     }
 }

--- a/src/test/kotlin/com/amazon/ionelement/util/TestUtils.kt
+++ b/src/test/kotlin/com/amazon/ionelement/util/TestUtils.kt
@@ -36,4 +36,4 @@ fun convertToString(ionValue: IonValue): String {
  *
  * This is to support this somewhat commonly used scenario.
  */
-val INCLUDE_LOCATION_META = IonElementLoaderOptions(includeLocationMeta = true)
+val INCLUDE_LOCATION_META = IonElementLoaderOptions { includeLocationMeta = true }


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

This follows up on something I noted in #103—namely that sometimes the data loads faster if you "fallback" to iterative loading at `depth=0`.

* Makes `IonElementLoaderOptions` _not_ a data class, so that we can change it without it being a potentially breaking change every time.
* Adds a builder class for `IonElementLoaderOptions`
* Adds `useRecursiveLoad` option to `IonElementLoaderOptions`
* Updates `IonElementLoaderImpl` to use the `useRecursiveLoad` option


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

